### PR TITLE
added banlist backup script

### DIFF
--- a/backup-banlist.sh
+++ b/backup-banlist.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Backup script for banlist and server setting files.
+# It can be run from anywhere.
+# Written by tobi-the-fraggel.
+
+
+# source directories
+ban="mods/pr/settings/banlist.con"
+info="mods/pr/settings/banlist_info.log"
+settings="settings"
+
+# backup destination
+des="/home/pradmin/pr_servers/fcv/admin/logs/banlist_backups"
+
+# removing all files older then 30 days from backups
+find $des -type f -mtime +30 -exec rm {} \;
+
+#syncing loop
+for p in fcv
+do
+cd /home/pradmin/pr_servers/
+        if [ -e $p/$ban ]; then
+        rsync -rt $p/$ban $des/banlist.con$(date +%Y.%m.%d_%H:%M:%S)
+        fi
+#        if [ -e $p/$info ]; then
+#        rsync -rt $p/$info $des/$p/banlist_info.log$(date +%Y.%m.%d_%H:%M:%S)
+#        fi
+#        if [ -d $p/$settings ]; then
+#        rsync -rt $p/$settings $des/$p
+#        fi
+done


### PR DESCRIPTION
As requested I added the fcv version of my banlist backup script.
Problem is that it is not really portable. Paths need to be adjusted by the server owner.
Reasoning for the for loop is to be able to backup mutiple servers at once. When running multiple servers the server root folders should be numbered. Like 1,2,3,4...etc.
The loop then needs to look like 'for p in {1..4}' to backup 4 servers at once. The 'rsync' destination also needs to be adjusted when backing up more then one server to avoid putting backups all in one directory causing them to overwrite each other. So yea this script needs to be tested carefully before relying on it.
